### PR TITLE
Analytics service implementation

### DIFF
--- a/shopcart-backend/src/main/java/com/shopcart/backend/controller/AnalyticsRestController.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/controller/AnalyticsRestController.java
@@ -1,0 +1,96 @@
+package com.shopcart.backend.controller;
+
+import java.util.Calendar;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.shopcart.backend.entity.Order;
+import com.shopcart.backend.entity.VisitEvent;
+import com.shopcart.backend.entity.VisitEvent.Event;
+import com.shopcart.backend.repository.OrderRepository;
+import com.shopcart.backend.repository.VisitEventRepository;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsRestController {
+
+	private final String[] months = {
+			"January",
+			"February",
+			"March",
+			"April",
+			"May",
+			"June",
+			"July",
+			"August",
+			"September",
+			"October",
+			"November",
+			"December"
+	};
+	
+    private final OrderRepository orderRepository;
+    private final VisitEventRepository visitEventRepository;
+
+    public AnalyticsRestController(OrderRepository orderRepository, VisitEventRepository visitEventRepository) {
+        this.orderRepository = orderRepository;
+        this.visitEventRepository = visitEventRepository;
+    }
+
+	@GetMapping("report/monthly/items")
+    public String getMonthlyItemsSold() {
+    	int[] quantities_sold = new int[12];
+    	for(Order order : orderRepository.findAll()) {
+    		Calendar cal = Calendar.getInstance();
+    		cal.setTime(order.getDate());
+    		int month = cal.get(Calendar.MONTH);
+        	for(Map.Entry<Long, Integer> entry : order.getProducts().entrySet()) {
+        		quantities_sold[month] += entry.getValue();
+        	}
+    	}
+
+    	// Return Monthly Items Sold
+    	StringBuilder result = new StringBuilder();
+    	result.append("{");
+    	for(int i = 0; i < months.length; i ++) {
+    		result.append("\"" + months[i] + "\":");
+    		result.append(quantities_sold[i]);
+			if(i < months.length - 1) result.append(", ");
+    	}
+    	result.append("}");
+    	return result.toString();
+    }
+
+	@GetMapping("report/website/usage")
+    public String getWebsiteUsage() {
+		int view_hits = visitEventRepository.findByEvent(Event.VIEW).size();
+		int cart_hits = visitEventRepository.findByEvent(Event.CART).size();
+		int purchase_hits = visitEventRepository.findByEvent(Event.PURCHASE).size();
+
+    	// Return Website Usage
+    	StringBuilder result = new StringBuilder();
+    	result.append("{\"view\":");
+    	result.append(view_hits);
+    	result.append(", \"cart\":");
+    	result.append(cart_hits);
+    	result.append(", \"purchase\":");
+    	result.append(purchase_hits + "}");
+    	return result.toString();
+	}
+
+	@PostMapping("report/website/usage")
+    public void addPageVisit(@RequestBody VisitEvent visitEvent) {
+		visitEventRepository.save(visitEvent);
+	}
+	
+	@DeleteMapping("report/website/usage")
+    public void deletePageVisit(@RequestBody VisitEvent visitEvent) {
+		visitEventRepository.delete(visitEvent);
+	}
+}

--- a/shopcart-backend/src/main/java/com/shopcart/backend/entity/Order.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/entity/Order.java
@@ -34,7 +34,7 @@ public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    @Column(nullable = false, updatable = false)
+    @Column(name="date", nullable = false, updatable = false)
     @CreationTimestamp
     private Date date;
     @Column(name="total")

--- a/shopcart-backend/src/main/java/com/shopcart/backend/entity/Order.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/entity/Order.java
@@ -1,11 +1,8 @@
 package com.shopcart.backend.entity;
 
 import java.sql.Date;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.persistence.CollectionTable;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -14,7 +11,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 
@@ -48,11 +44,9 @@ public class Order {
     @Column(name="status")
     @Enumerated(EnumType.STRING)
     private Status status;
+    @Column(name="product_ids")
     @ElementCollection
-    @CollectionTable(name = "order_products")
-    @MapKeyColumn(name="product_id")
-    @Column(name="quantity")
-    Map<Long, Integer> products = new HashMap<Long, Integer>();
+    private List<Long> product_ids = new ArrayList<Long>();
     
 	public long getId() {
 		return id;
@@ -118,16 +112,16 @@ public class Order {
 		}
 	}
 
-	public void addProduct(long product_id, int quantity){
-		products.put(product_id, quantity);
-	}
+    public void addProduct_id(long product_id){
+    	product_ids.add(product_id);
+    }
 
-	public void removeProduct(long product_id){
-		products.remove(product_id);
-	}
+    public void removeProduct_id(long product_id){
+    	product_ids.remove(product_id);
+    }
 
-	public Map<Long, Integer> getProducts() {
-		return products;
+	public List<Long> getProduct_ids() {
+		return product_ids;
 	}
 
 	@Override
@@ -136,7 +130,8 @@ public class Order {
 			Order other = (Order) object;
 			return this.id == other.id && this.total == other.total && this.country.equals(other.country)
 					&& this.first_name.equals(other.first_name) && this.last_name.equals(other.last_name)
-					&& this.products.equals(other.products) && this.status.getValue() == other.status.getValue();
+					&& this.status.getValue() == other.status.getValue() && this.product_ids.containsAll(other.product_ids)
+					&& other.product_ids.containsAll(this.product_ids);
 		} else {
 			return false;
 		}

--- a/shopcart-backend/src/main/java/com/shopcart/backend/entity/Product.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/entity/Product.java
@@ -32,8 +32,6 @@ public class Product {
     private String color;
     @Column(name="price")
     private @NotBlank float price;
-    @Column(name="quantity")
-    private @NotBlank int quantity;
     @Column(name="review_ids")
     @ElementCollection
     private List<Long> review_ids = new ArrayList<Long>();
@@ -97,14 +95,6 @@ public class Product {
 
     public void setPrice(float price) {
         this.price = price;
-    }
-
-    public int getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(int quantity) {
-        this.quantity = quantity;
     }
 
     public void addReview_id(long review_id){

--- a/shopcart-backend/src/main/java/com/shopcart/backend/entity/VisitEvent.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/entity/VisitEvent.java
@@ -1,0 +1,75 @@
+package com.shopcart.backend.entity;
+
+import java.sql.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name="visit_event")
+public class VisitEvent {
+
+	public enum Event {
+		VIEW(1), CART(2), PURCHASE(3);
+		private int value;
+		Event(int value) { this.value = value; }
+		public int getValue() { return value; }
+	}
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @Column(name="date", nullable = false, updatable = false)
+    @CreationTimestamp
+    private Date date;
+    @Column(name="ip_address")
+    private String ip_address;
+    @Column(name="event")
+    @Enumerated(EnumType.STRING)
+    private Event event;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public String getIp_address() {
+		return ip_address;
+	}
+
+	public void setIp_address(String ip_address) {
+		this.ip_address = ip_address;
+	}
+
+	public Event getEvent() {
+		return event;
+	}
+
+	public void setEvent(int event) {
+		if(event == 1) {
+			this.event = Event.VIEW;
+		} else if(event == 2) {
+			this.event = Event.CART;
+		} else if(event == 3) {
+			this.event = Event.PURCHASE;
+		}
+	}
+}

--- a/shopcart-backend/src/main/java/com/shopcart/backend/repository/VisitEventRepository.java
+++ b/shopcart-backend/src/main/java/com/shopcart/backend/repository/VisitEventRepository.java
@@ -1,0 +1,14 @@
+package com.shopcart.backend.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.shopcart.backend.entity.VisitEvent;
+import com.shopcart.backend.entity.VisitEvent.Event;
+
+@Repository
+public interface VisitEventRepository extends CrudRepository<VisitEvent, Long> {
+	List<VisitEvent> findByEvent(Event event);
+}


### PR DESCRIPTION
<!-- Title -->
# 
## Proposed Changes
- analytics service
- Visit Event Entity
- /api/analytics/monthly/items -> get the monthly items sold stats GET
- /api/analytics/website/usage -> get the page hit stats GET
- /api/analytics/website/usage -> add a visit event POST
- /api/analytics/website/usage -> delete a visit event DELETE

## Estimated Review Time
<!-- Let your reviewer know how big this PR is (minutes) -->
- 15-20 minutes

## Screenshots / Code Snippets

### To test changes
First follow from #21 to make an order or two. Updated changes here make products exclude the quantity field now and order products to be passed as a list ( [1, 2] ) instead of a map ( {1 : 2,  2: 5 } )
Then you can run 
/api/analytics/report/monthly/items GET

to then receive a object back with the items sold for each month (since we auto timestamp orders items will only be sold in March as of right now)

Then to test the visit event object you can run

 /api/analytics/report/website/usage POST 

> {
        "ip_address": "1.27.0.0.0",
        "event": 2
}

You can do this many times and try changing the event in the body to any 1, 2, 3 and once your done do a

/api/analytics/report/website/usage GET and it should display the hits for each of the three main pages